### PR TITLE
Strip HTML comments from LLM feed content

### DIFF
--- a/src/lib/posts/lazy-market-hypothesis.md
+++ b/src/lib/posts/lazy-market-hypothesis.md
@@ -3,6 +3,7 @@ title: the Lazy Market Hypothesis
 tagline: Some markets are (allegedly) efficient. Some markets are efficiently lazy.
 tags: ['artificial-intelligence']
 version: v0.0.1
+draft: true
 ---
 
 (continuing from the tagline: (, at their local optimums.))

--- a/src/routes/llms.txt/+server.ts
+++ b/src/routes/llms.txt/+server.ts
@@ -1,5 +1,6 @@
 import { public_posts, type Article } from '$lib/load_posts';
 import { load_tags, type TagArticle } from '$lib/load_tags';
+import { stripComments } from '$lib/remark-plugins';
 import { title, website } from '../constants';
 
 export const prerender = true;
@@ -40,7 +41,7 @@ const format = (posts: Article[], tags: TagArticle[]) => {
 			const url = `${website}${post.link}`;
 			const date = post.createdAt.toISOString().slice(0, 10);
 			const tagList = post.tags.join(', ');
-			const content = contentBySlug[post.slug] ?? '';
+			const content = stripComments(contentBySlug[post.slug] ?? '');
 			const tagline = post.tagline ? `> ${post.tagline}\n\n` : '';
 			return `## ${post.title}\n\n${url} | ${date} | tags: ${tagList}\n\n${tagline}${content}`;
 		})


### PR DESCRIPTION
## Summary
This PR filters out HTML comments from post content in the LLM feed endpoint to prevent internal comments from being exposed in the generated feed.

## Key Changes
- Import `stripComments` utility from remark-plugins
- Apply `stripComments()` to post content when generating the LLM feed format
- Mark the "Lazy Market Hypothesis" post as draft

## Implementation Details
The `stripComments` function is now applied to the content retrieved from `contentBySlug` before it's included in the formatted feed output. This ensures that any HTML comments embedded in markdown content (which may contain internal notes or metadata) are removed before being served to LLM consumers.

https://claude.ai/code/session_019JhyXNnuVLYFnWm6JN9R59